### PR TITLE
Изменения:

### DIFF
--- a/Metrics Manager/Metrics Manager.sln
+++ b/Metrics Manager/Metrics Manager.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31402.337
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Metrics Manager", "Metrics Manager\Metrics Manager.csproj", "{B1011D0D-DBFB-4188-ADA1-865AD0DBEAFD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetricsManagerTests", "MetricsManagerTests\MetricsManagerTests.csproj", "{2FED1B5A-5E4B-406D-9C27-C6187E3C8627}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetricsAgent", "MetricsAgent\MetricsAgent.csproj", "{4DB07595-43B1-4E07-9FF8-2C13F3FA4B39}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetricsAgentTests", "MetricsAgentTests\MetricsAgentTests.csproj", "{A1586643-C2A4-4B5D-B293-A45B72AA2CB6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B1011D0D-DBFB-4188-ADA1-865AD0DBEAFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1011D0D-DBFB-4188-ADA1-865AD0DBEAFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1011D0D-DBFB-4188-ADA1-865AD0DBEAFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1011D0D-DBFB-4188-ADA1-865AD0DBEAFD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2FED1B5A-5E4B-406D-9C27-C6187E3C8627}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FED1B5A-5E4B-406D-9C27-C6187E3C8627}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FED1B5A-5E4B-406D-9C27-C6187E3C8627}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FED1B5A-5E4B-406D-9C27-C6187E3C8627}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4DB07595-43B1-4E07-9FF8-2C13F3FA4B39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4DB07595-43B1-4E07-9FF8-2C13F3FA4B39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4DB07595-43B1-4E07-9FF8-2C13F3FA4B39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4DB07595-43B1-4E07-9FF8-2C13F3FA4B39}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1586643-C2A4-4B5D-B293-A45B72AA2CB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1586643-C2A4-4B5D-B293-A45B72AA2CB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1586643-C2A4-4B5D-B293-A45B72AA2CB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1586643-C2A4-4B5D-B293-A45B72AA2CB6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {27B073A7-844D-4B4E-846E-B98FEF019ECD}
+	EndGlobalSection
+EndGlobal

--- a/Metrics Manager/Metrics Manager/Controllers/AgentsController.cs
+++ b/Metrics Manager/Metrics Manager/Controllers/AgentsController.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Metrics_Manager.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class AgentsController : ControllerBase
+    {
+        
+
+        [HttpPost("register")]
+        public IActionResult RegisterAgent([FromBody] AgentInfo agentInfo)
+        {
+            return Ok();
+        }
+
+        [HttpPut("enable/{agentId}")]
+        public IActionResult EnableAgentById([FromRoute] int agentId)
+        {
+            return Ok();
+        }
+
+        [HttpPut("disable/{agentId}")]
+        public IActionResult DisableAgentById([FromRoute] int agentId)
+        {
+            return Ok();
+        }
+
+        [HttpGet("agents")]
+        public IActionResult GetRegisteredAgents()
+        {
+            return Ok();
+        }
+
+    }
+
+}

--- a/Metrics Manager/Metrics Manager/Controllers/CpuMetricsController.cs
+++ b/Metrics Manager/Metrics Manager/Controllers/CpuMetricsController.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Metrics_Manager.Controllers
+{
+    [Route("api/metrics/cpu")]
+    [ApiController]
+    public class CpuMetricsController : ControllerBase
+    {
+        [HttpGet("agent/{agentId}/from/{fromTime}/to/{toTime}")]
+        public IActionResult GetMetricsFromAgent([FromRoute] int agentId, [FromRoute] DateTimeOffset fromTime, [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+
+        [HttpGet("cluster/from/{fromTime}/to/{toTime}")]
+        public IActionResult GetMetricsFromAllCluster([FromRoute] DateTimeOffset fromTime, [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+    }
+}

--- a/Metrics Manager/Metrics Manager/Controllers/DotNetMetricsController.cs
+++ b/Metrics Manager/Metrics Manager/Controllers/DotNetMetricsController.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Metrics_Manager.Controllers
+{
+    [Route("api/metrics/dotnet")]
+    [ApiController]
+    public class DotNetMetricsController : ControllerBase
+    {
+        [HttpGet("agent/{agentId}/from/{fromTime}/to/{toTime}")]
+        public IActionResult GetMetricsFromAgent([FromRoute] int agentId, [FromRoute] DateTimeOffset fromTime, [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+
+        [HttpGet("cluster/from/{fromTime}/to/{toTime}")]
+        public IActionResult GetMetricsFromAllCluster([FromRoute] DateTimeOffset fromTime, [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+    }
+}

--- a/Metrics Manager/Metrics Manager/Controllers/HddMetricsController.cs
+++ b/Metrics Manager/Metrics Manager/Controllers/HddMetricsController.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Metrics_Manager.Controllers
+{
+    [Route("api/metrics/hdd")]
+    [ApiController]
+    public class HddMetricsController : ControllerBase
+    {
+        [HttpGet("agent/{agentId}/from/{fromTime}/to/{toTime}")]
+        public IActionResult GetMetricsFromAgent([FromRoute] int agentId, [FromRoute] DateTimeOffset fromTime, [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+
+        [HttpGet("cluster/from/{fromTime}/to/{toTime}")]
+        public IActionResult GetMetricsFromAllCluster([FromRoute] DateTimeOffset fromTime, [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+    }
+}

--- a/Metrics Manager/Metrics Manager/Controllers/NetworkMetricsController.cs
+++ b/Metrics Manager/Metrics Manager/Controllers/NetworkMetricsController.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Metrics_Manager.Controllers
+{
+    [Route("api/metrics/network")]
+    [ApiController]
+    public class NetworkMetricsController : ControllerBase
+    {
+        [HttpGet("agent/{agentId}/from/{fromTime}/to/{toTime}")]
+        public IActionResult GetMetricsFromAgent([FromRoute] int agentId, [FromRoute] DateTimeOffset fromTime, [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+
+        [HttpGet("cluster/from/{fromTime}/to/{toTime}")]
+        public IActionResult GetMetricsFromAllCluster([FromRoute] DateTimeOffset fromTime, [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+    }
+}

--- a/Metrics Manager/Metrics Manager/Controllers/RamMetricsController.cs
+++ b/Metrics Manager/Metrics Manager/Controllers/RamMetricsController.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Metrics_Manager.Controllers
+{
+    [Route("api/metrics/ram")]
+    [ApiController]
+    public class RamMetricsController : ControllerBase
+    {
+        [HttpGet("agent/{agentId}/from/{fromTime}/to/{toTime}")]
+        public IActionResult GetMetricsFromAgent([FromRoute] int agentId, [FromRoute] DateTimeOffset fromTime, [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+
+        [HttpGet("cluster/from/{fromTime}/to/{toTime}")]
+        public IActionResult GetMetricsFromAllCluster([FromRoute] DateTimeOffset fromTime, [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+    }
+}

--- a/Metrics Manager/Metrics Manager/Metrics Manager.csproj
+++ b/Metrics Manager/Metrics Manager/Metrics Manager.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace>Metrics_Manager</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+  </ItemGroup>
+
+</Project>

--- a/Metrics Manager/Metrics Manager/Models/AgentInfo.cs
+++ b/Metrics Manager/Metrics Manager/Models/AgentInfo.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Metrics_Manager
+{
+    public class AgentInfo
+    {
+        public int AgentId { get; }
+        public Uri AgentAddress { get; }
+    }
+}

--- a/Metrics Manager/Metrics Manager/Program.cs
+++ b/Metrics Manager/Metrics Manager/Program.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Metrics_Manager
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/Metrics Manager/Metrics Manager/Properties/launchSettings.json
+++ b/Metrics Manager/Metrics Manager/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:13842",
+      "sslPort": 44319
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Metrics_Manager": {
+      "commandName": "Project",
+      "dotnetRunMessages": "true",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Metrics Manager/Metrics Manager/Startup.cs
+++ b/Metrics Manager/Metrics Manager/Startup.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Metrics_Manager
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+
+            services.AddControllers();
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Metrics_Manager", Version = "v1" });
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+                app.UseSwagger();
+                app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Metrics_Manager v1"));
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/Metrics Manager/Metrics Manager/appsettings.Development.json
+++ b/Metrics Manager/Metrics Manager/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/Metrics Manager/Metrics Manager/appsettings.json
+++ b/Metrics Manager/Metrics Manager/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/Metrics Manager/MetricsAgent/Controllers/CpuAgentController.cs
+++ b/Metrics Manager/MetricsAgent/Controllers/CpuAgentController.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MetricsAgent.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class CpuAgentController : ControllerBase
+    {
+        [HttpGet("from/{fromTime}/to/{toTime}")]
+        public IActionResult GetMetricsAgent(int agentId,
+            [FromRoute] DateTimeOffset fromTime,
+            [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+    }
+}

--- a/Metrics Manager/MetricsAgent/Controllers/DotNetAgentController.cs
+++ b/Metrics Manager/MetricsAgent/Controllers/DotNetAgentController.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MetricsAgent.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class DotNetAgentController : ControllerBase
+    {
+        [HttpGet("errors-count/from/{fromTime}/to/{toTime}")]
+        public IActionResult GetErrorsCount([FromRoute] DateTimeOffset fromTime, [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+    }
+}

--- a/Metrics Manager/MetricsAgent/Controllers/HddAgentController.cs
+++ b/Metrics Manager/MetricsAgent/Controllers/HddAgentController.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MetricsAgent.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class HddAgentController : ControllerBase
+    {
+        [HttpGet("left")]
+        public IActionResult GetFreeDiskSpace()
+        {
+            return Ok();
+        }
+        [HttpGet("from/{fromTime}/to/{toTime}")]
+        public IActionResult GetFreeDiskForPeriod([FromRoute] DateTimeOffset fromTime,
+            [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+    }
+}

--- a/Metrics Manager/MetricsAgent/Controllers/NetworkAgentController.cs
+++ b/Metrics Manager/MetricsAgent/Controllers/NetworkAgentController.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MetricsAgent.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class NetworkAgentController : ControllerBase
+    {
+        [HttpGet("/from/{fromTime}/to/{toTime}")]
+        public IActionResult GetNetworkData([FromRoute] DateTimeOffset fromTime,
+            [FromRoute] DateTimeOffset toTime)
+        {
+            return Ok();
+        }
+    }
+}

--- a/Metrics Manager/MetricsAgent/Controllers/RamAgentController.cs
+++ b/Metrics Manager/MetricsAgent/Controllers/RamAgentController.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MetricsAgent.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class RamAgentController : ControllerBase
+    {
+        [HttpGet("available")]
+        public IActionResult GetFreeSpaceRum()
+        {
+            return Ok();
+        }
+        [HttpGet("from/{fromTime}/to/{toTime}")]
+        public IActionResult GetFreeRamForPeriodOfTime([FromRoute] TimeSpan fromTime,
+            [FromRoute] TimeSpan toTime)
+        {
+            return Ok();
+        }
+    }
+}

--- a/Metrics Manager/MetricsAgent/MetricsAgent.csproj
+++ b/Metrics Manager/MetricsAgent/MetricsAgent.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+  </ItemGroup>
+
+</Project>

--- a/Metrics Manager/MetricsAgent/Program.cs
+++ b/Metrics Manager/MetricsAgent/Program.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MetricsAgent
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/Metrics Manager/MetricsAgent/Properties/launchSettings.json
+++ b/Metrics Manager/MetricsAgent/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:58779",
+      "sslPort": 44388
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "MetricsAgent": {
+      "commandName": "Project",
+      "dotnetRunMessages": "true",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Metrics Manager/MetricsAgent/Startup.cs
+++ b/Metrics Manager/MetricsAgent/Startup.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MetricsAgent
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+
+            services.AddControllers();
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "MetricsAgent", Version = "v1" });
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+                app.UseSwagger();
+                app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "MetricsAgent v1"));
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/Metrics Manager/MetricsAgent/appsettings.Development.json
+++ b/Metrics Manager/MetricsAgent/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/Metrics Manager/MetricsAgent/appsettings.json
+++ b/Metrics Manager/MetricsAgent/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/Metrics Manager/MetricsAgentTests/MetricsAgentTests.csproj
+++ b/Metrics Manager/MetricsAgentTests/MetricsAgentTests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MetricsAgent\MetricsAgent.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Metrics Manager/MetricsAgentTests/UnitTest1.cs
+++ b/Metrics Manager/MetricsAgentTests/UnitTest1.cs
@@ -1,0 +1,113 @@
+using MetricsAgent.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using Xunit;
+
+namespace MetricsAgentTests
+{
+    public class CpuAgentControllerUnitTests
+    {
+        private CpuAgentController Controller;
+
+        public CpuAgentControllerUnitTests()
+        {
+            Controller = new CpuAgentController();
+        }
+
+        [Fact]
+        public void GetMetricsFromAgent_returnsOk()
+        {
+            var agentId = 1;
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            var result = Controller.GetMetricsAgent(agentId, fromTime, toTime);
+
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+    }
+    public class DotNetAgentControllerUnitTests
+    {
+        private CpuAgentController Controller;
+
+        public DotNetAgentControllerUnitTests()
+        {
+            Controller = new CpuAgentController();
+        }
+
+        [Fact]
+        public void GetMetricsFromAgent_returnsOk()
+        {
+            var agentId = 1;
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            var result = Controller.GetMetricsAgent(agentId, fromTime, toTime);
+
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+    }
+    public class HddAgentControllerUnitTests
+    {
+        private CpuAgentController Controller;
+
+        public HddAgentControllerUnitTests()
+        {
+            Controller = new CpuAgentController();
+        }
+
+        [Fact]
+        public void GetMetricsFromAgent_returnsOk()
+        {
+            var agentId = 1;
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            var result = Controller.GetMetricsAgent(agentId, fromTime, toTime);
+
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+    }
+    public class NetworkAgentControllerUnitTests
+    {
+        private CpuAgentController Controller;
+
+        public NetworkAgentControllerUnitTests()
+        {
+            Controller = new CpuAgentController();
+        }
+
+        [Fact]
+        public void GetMetricsFromAgent_returnsOk()
+        {
+            var agentId = 1;
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            var result = Controller.GetMetricsAgent(agentId, fromTime, toTime);
+
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+    }
+    public class RamAgentControllerUnitTests
+    {
+        private CpuAgentController Controller;
+
+        public RamAgentControllerUnitTests()
+        {
+            Controller = new CpuAgentController();
+        }
+
+        [Fact]
+        public void GetMetricsFromAgent_returnsOk()
+        {
+            var agentId = 1;
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            var result = Controller.GetMetricsAgent(agentId, fromTime, toTime);
+
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+    }
+}

--- a/Metrics Manager/MetricsManagerTests/MetricsManagerTests.csproj
+++ b/Metrics Manager/MetricsManagerTests/MetricsManagerTests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Metrics Manager\Metrics Manager.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Metrics Manager/MetricsManagerTests/UnitTest1.cs
+++ b/Metrics Manager/MetricsManagerTests/UnitTest1.cs
@@ -1,0 +1,176 @@
+using Metrics_Manager.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using Xunit;
+
+namespace MetricsManagerTests
+{
+    public class CpuMetricsControllerUnitTests
+    {
+        private CpuMetricsController Controller;
+
+        public CpuMetricsControllerUnitTests()
+        {
+            Controller = new CpuMetricsController();
+        }
+
+        [Fact]
+        public void GetMetricsFromAgent_returnsOk()
+        {
+            var agentId = 1;
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            var result = Controller.GetMetricsFromAgent(agentId, fromTime, toTime);
+
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+
+        [Fact]
+        public void GetMetricsFromAllClaster_RetunsOk()
+        {
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            //Act
+            var result = Controller.GetMetricsFromAllCluster(fromTime, toTime);
+
+            //Assert
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+
+    }
+    public class DotNetMetricsControllerUnitTests
+    {
+        private DotNetMetricsController controller;
+
+        public DotNetMetricsControllerUnitTests()
+        {
+            controller = new DotNetMetricsController();
+        }
+
+        [Fact]
+        public void GetMetricsFromAgent_returnsOk()
+        {
+            var agentId = 1;
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            var result = controller.GetMetricsFromAgent(agentId, fromTime, toTime);
+
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+        [Fact]
+        public void GetMetricsFromAllClaster_RetunsOk()
+        {
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            //Act
+            var result = controller.GetMetricsFromAllCluster(fromTime, toTime);
+
+            //Assert
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+    }
+    public class HddMetricsControllerUnitTests
+    {
+        private HddMetricsController controller;
+
+        public HddMetricsControllerUnitTests()
+        {
+            controller = new HddMetricsController();
+        }
+
+        [Fact]
+        public void GetMetricsFromAgent_returnsOk()
+        {
+            var agentId = 1;
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            var result = controller.GetMetricsFromAgent(agentId, fromTime, toTime);
+
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+        [Fact]
+        public void GetMetricsFromAllClaster_RetunsOk()
+        {
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            //Act
+            var result = controller.GetMetricsFromAllCluster(fromTime, toTime);
+
+            //Assert
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+    }
+    public class NetworkMetricsControllerUnitTests
+    {
+        private NetworkMetricsController controller;
+
+        public NetworkMetricsControllerUnitTests()
+        {
+            controller = new NetworkMetricsController();
+        }
+
+        [Fact]
+        public void GetMetricsFromAgent_returnsOk()
+        {
+            var agentId = 1;
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            var result = controller.GetMetricsFromAgent(agentId, fromTime, toTime);
+
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+        [Fact]
+        public void GetMetricsFromAllClaster_RetunsOk()
+        {
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            //Act
+            var result = controller.GetMetricsFromAllCluster(fromTime, toTime);
+
+            //Assert
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+
+    }
+    public class RamMetricsControllerUnitTests
+    {
+        private RamMetricsController controller;
+
+        public RamMetricsControllerUnitTests()
+        {
+            controller = new RamMetricsController();
+        }
+
+        [Fact]
+        public void GetMetricsFromAgent_returnsOk()
+        {
+            var agentId = 1;
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            var result = controller.GetMetricsFromAgent(agentId, fromTime, toTime);
+
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+        [Fact]
+        public void GetMetricsFromAllClaster_RetunsOk()
+        {
+            var fromTime = DateTimeOffset.FromUnixTimeSeconds(0);
+            var toTime = DateTimeOffset.FromUnixTimeSeconds(100);
+
+            //Act
+            var result = controller.GetMetricsFromAllCluster(fromTime, toTime);
+
+            //Assert
+            _ = Assert.IsAssignableFrom<IActionResult>(result);
+        }
+    }
+}


### PR DESCRIPTION
1. Добавлен метод в контроллер агентов проекта менеджера метрик позволяющий получить список зарегистрированных в системе объектов.
2. В проект агента сбора метрик добавлены контроллеры для сбора метрик, аналогичные менеджеру сбора метрик. Добавлены методы для получения метрик с агента, доступные по следующим путям:

api/metrics/cpu/from/{fromTime}/to/{toTime}/percentiles/{percentile}
api/metrics/cpu//from/{fromTime}/to/{toTime}/
api/metrics/dotnet/errors-count/from/{fromTime}/to/{toTime}
api/metrics/network/from/{fromTime}/to/{toTime}/
api/metrics/hdd/left (размер оставшегося свободного дискового пространства в мегабайтах)
api/metrics/ram/available (размер свободной оперативной памяти в мегабайтах)

3. Добавлен проект с тестами для агента сбора метрик. Написаны простые юнит-тесты на каждый метод каждого контроллера в обоих тестовых проектах.